### PR TITLE
[TECH-82] Remove MySQL as a requirement for dev environments

### DIFF
--- a/Casks/flywheel-developer.rb
+++ b/Casks/flywheel-developer.rb
@@ -23,7 +23,6 @@ cask 'flywheel-developer' do
                libyaml
                pkg-config
                puma-dev
-               mysql
                redis
                docker-compose
                kubectl


### PR DESCRIPTION
After getflywheel/flywheel-app#8412 is merged, we no longer need to have
MySQL installed to get the app running. As such, let's stop installing
it during laptop setup since it's the most fragile piece of software we
install.